### PR TITLE
Add JSON output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Glob patterns allow you to query multiple files at once:
 - Use the alias feature to simplify queries and avoid shell parsing issues
 - You can use standard SQL syntax supported by DuckDB
 - The output uses DuckDB's built-in formatting for readability
-- Use `--output-format csv` or `--output-format tsv` for machine readable output
+- Use `--output-format csv`, `--output-format tsv`, or `--output-format json` for machine readable output
 - Query execution time is displayed after each query
 
 ## Requirements

--- a/pksql/main.py
+++ b/pksql/main.py
@@ -3,6 +3,7 @@
 import sys
 import os
 import time
+import json
 import click
 import duckdb
 from rich.console import Console
@@ -15,7 +16,7 @@ console = Console()
 @click.argument('args', nargs=-1)
 @click.option('--interactive', '-i', is_flag=True, help='Start in interactive mode')
 @click.option('--output-format', '-F', 'output_format',
-              type=click.Choice(['table', 'csv', 'tsv'], case_sensitive=False),
+              type=click.Choice(['table', 'csv', 'tsv', 'json'], case_sensitive=False),
               default='table',
               help='Output format for query results')
 def cli(args, interactive, output_format):
@@ -89,13 +90,19 @@ def cli(args, interactive, output_format):
                 if is_query:
                     # Display results using DuckDB's pretty formatting
                     print(result)
-            else:
+            elif output_format in ("csv", "tsv"):
                 delimiter = "," if output_format == "csv" else "\t"
                 if is_query:
                     header = delimiter.join(result.columns)
                     print(header)
                     for row in result.fetchall():
                         print(delimiter.join(map(str, row)))
+                else:
+                    console.print("Query executed successfully.")
+            elif output_format == "json":
+                if is_query:
+                    rows = [dict(zip(result.columns, row)) for row in result.fetchall()]
+                    print(json.dumps(rows))
                 else:
                     console.print("Query executed successfully.")
             

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 import pytest
 import duckdb
+import json
 
 from click.testing import CliRunner
 from pksql.main import cli
@@ -37,6 +38,15 @@ def test_cli_tsv_output():
     # TSV header and row should be printed with tab separation
     assert "a\tb" in result.output
     assert "1\t2" in result.output
+
+
+def test_cli_json_output():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--output-format", "json", "SELECT 1 AS a, 2 AS b"])
+    assert result.exit_code == 0
+    first_line = result.output.splitlines()[0]
+    data = json.loads(first_line)
+    assert data == [{"a": 1, "b": 2}]
 
 
 def test_cli_invalid_query():


### PR DESCRIPTION
## Summary
- extend `--output-format` to support `json`
- print query results as JSON when selected
- document the new output format option
- test JSON CLI output

## Testing
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864ed7368588327b4617ce4a9d87d35